### PR TITLE
remove --progress=plain option from docker_build script

### DIFF
--- a/docker_build.sh
+++ b/docker_build.sh
@@ -24,7 +24,7 @@ LOG_FILE="$LOG_DIR/docker_build.log"
 echo "A build log is stored at : file://$LOG_FILE"
 
 # shellcheck disable=SC2086
-docker build ${opts} --progress=plain --target "${target}" -t "aichallenge-2025-${target}-${USER}" . 2>&1 | tee "$LOG_FILE"
+docker build ${opts} --target "${target}" -t "aichallenge-2025-${target}-${USER}" . 2>&1 | tee "$LOG_FILE"
 echo "========================================================"
 echo "This log is in : file://$LOG_FILE"
 echo "========================================================"


### PR DESCRIPTION
This PR contains:
- Removal of `--progress` flag due to incompatibility with newer Docker versions